### PR TITLE
SolrConnection should have a string representation

### DIFF
--- a/Classes/System/Solr/SolrConnection.php
+++ b/Classes/System/Solr/SolrConnection.php
@@ -222,4 +222,15 @@ class SolrConnection
 
         return $service;
     }
+
+    /**
+     * Creates a string representation of the Solr connection. Specifically
+     * will return the Solr URL.
+     *
+     * @return string The Solr URL.
+     */
+    public function __toString()
+    {
+        return $this->scheme . '://' . $this->host . ':' . $this->port . $this->path;
+    }
 }


### PR DESCRIPTION
During to the `SolrService/SolrConnection` refactoring, the method `__toString()` is missing, but still called in 
`Classes/IndexQueue/FrontendHelper/PageIndexer.php` (line 303) causing in Fatal (but recoverable) PHP Errors while indexing.

The patch adds the missing method again, which works just fine for our use cases (TYPO3 v9, solr-master)